### PR TITLE
Remove ARIN-WHOIS from NTTCOM listing

### DIFF
--- a/src/content/registry-list.json
+++ b/src/content/registry-list.json
@@ -177,7 +177,6 @@
       "BBOI",
       "TC",
       "AFRINIC",
-      "ARIN-WHOIS",
       "RPKI",
       "REGISTROBR"
     ],


### PR DESCRIPTION
rr.ntt.net / NTTCOM no longer mirrors ARIN-WHOIS.

Source: the gin.ntt.net website, and myself as one of the rr.ntt.net administrators.