### PR TITLE
ARIN switched from FTP to HTTPS

### DIFF
--- a/src/content/registry-list.json
+++ b/src/content/registry-list.json
@@ -34,7 +34,7 @@
   {
     "name": "ARIN",
     "dns_name": "rr.arin.net",
-    "ftp_site": ["ftp://ftp.arin.net/pub/rr/"],
+    "ftp_site": ["https://ftp.arin.net/pub/rr/"],
     "databases_mirrored": [],
     "mirror_port_and_info": "rr.arin.net, port 43",
     "whois_location": "rr.arin.net",

--- a/src/pages/registry.js
+++ b/src/pages/registry.js
@@ -27,7 +27,7 @@ const RegistryListPage = () => {
                 </tr>
                 {registry.ftp_site &&
                   <tr>
-                    <td>FTP Site:</td>
+                    <td>Download Site:</td>
                     <td>{registry.ftp_site.join(", ")}</td>
                   </tr>}
                 {registry.databases_mirrored &&


### PR DESCRIPTION
Per https://mailman.nanog.org/pipermail/nanog/2024-December/227032.html